### PR TITLE
Add Slack reaction tool

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -23,6 +23,7 @@
 - スレッド内でのメッセージ投稿
 - チャンネルへのメッセージ投稿
 - Slack 上での `mrkdwn` フォーマットに対応
+- メッセージにリアクションを追加
 
 #### 1. インストール方法
 
@@ -37,7 +38,7 @@ https://github.com/solaoi/dify-plugin-slack-post
 ##### 2-2. 本プラグインの利用には、以下のスコープが必要です。
 
 ```text
-chat:write
+chat:write, reactions:write
 ```
 
 ##### 2-3. 公式のSlackBotプラグインのセットアップ手順については以下をご参照ください。
@@ -68,6 +69,14 @@ https://github.com/langgenius/dify-official-plugins/blob/main/extensions/slack_b
 | thread_ts | Slack スレッドTS |
 | channel_id | Slack チャンネルID |
 | content | スレッドに投稿するメッセージ内容 |
+
+##### 3.3. Slackリアクション追加
+
+| 入力変数 | 説明 |
+| ---- | ---- |
+| channel_id | Slack チャンネルID |
+| timestamp | Slackメッセージのタイムスタンプ |
+| icon_name | 追加する絵文字の名前 |
 
 #### 4. オプション
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A Slack tool plugin for posting messages to channels or threads, with mrkdwn for
 - Post messages in a thread
 - Post messages to a channel
 - Supports Slack’s `mrkdwn` formatting
+- Add emoji reactions to messages
 
 #### 1. Install
 
@@ -37,7 +38,7 @@ https://github.com/solaoi/dify-plugin-slack-post
 ##### 2-2. The following scopes are required for this plugin:
 
 ```text
-chat:write
+chat:write, reactions:write
 ```
 
 ##### 2-3. For more details on setup the official SlackBot plugin, refer to:
@@ -68,6 +69,14 @@ https://github.com/langgenius/dify-official-plugins/blob/main/extensions/slack_b
 | thread_ts | Slack thread TS |
 | channel_id | Slack channel ID |
 | content | Content to be sent to the thread |
+
+##### 3.3. Slack Add Reaction
+
+| Input Variable | Description |
+| ---- | ---- |
+| channel_id | Slack channel ID |
+| timestamp | Timestamp of the Slack message |
+| icon_name | Name of the emoji to add |
 
 #### 4. Optional
 

--- a/README.pt_BR.md
+++ b/README.pt_BR.md
@@ -20,9 +20,10 @@ Um plugin de ferramenta do Slack para postar mensagens em canais ou threads, com
 
 #### Recursos
 
-- Enviar mensagens em uma thread  
-- Enviar mensagens em um canal  
+- Enviar mensagens em uma thread
+- Enviar mensagens em um canal
 - Suporta o formato `mrkdwn` do Slack
+- Adicionar reações a mensagens
 
 #### 1. Instalação
 
@@ -37,7 +38,7 @@ https://github.com/solaoi/dify-plugin-slack-post
 ##### 2-2. Este plugin requer os seguintes escopos:
 
 ```text
-chat:write
+chat:write, reactions:write
 ```
 
 ##### 2-3. Para mais detalhes sobre a configuração do plugin oficial SlackBot, consulte:
@@ -68,6 +69,14 @@ https://github.com/langgenius/dify-official-plugins/blob/main/extensions/slack_b
 | thread_ts | Slack thread TS |
 | channel_id | Slack channel ID |
 | content | Conteúdo a ser enviado para o thread |
+
+##### 3.3. Slack Add Reaction
+
+| Variável de entrada | Descrição |
+| ---- | ---- |
+| channel_id | Slack channel ID |
+| timestamp | Timestamp da mensagem do Slack |
+| icon_name | Nome do ícone emoji a ser adicionado |
 
 #### 4. Optional
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -20,9 +20,10 @@
 
 #### 功能
 
-- 在线程中发送消息  
-- 在频道中发送消息  
+- 在线程中发送消息
+- 在频道中发送消息
 - 支持Slack的 `mrkdwn` 格式
+- 为消息添加表情反应
 
 #### 1. 安装
 
@@ -37,7 +38,7 @@ https://github.com/solaoi/dify-plugin-slack-post
 ##### 2-2. 插件需要以下权限范围（Scopes）：
 
 ```text
-chat:write
+chat:write, reactions:write
 ```
 
 ##### 2-3. 有关官方SlackBot插件的详细设置步骤，请参考：
@@ -68,6 +69,14 @@ https://github.com/langgenius/dify-official-plugins/blob/main/extensions/slack_b
 | thread_ts | Slack 线程TS |
 | channel_id | Slack 频道ID |
 | content | 要发送到线程的消息内容 |
+
+##### 3.3. Slack 添加表情
+
+| 输入变量 | 说明 |
+| ---- | ---- |
+| channel_id | Slack 频道ID |
+| timestamp | Slack 消息的时间戳 |
+| icon_name | 要添加的表情名称 |
 
 #### 4. 可选功能
 

--- a/provider/slack_post.yaml
+++ b/provider/slack_post.yaml
@@ -21,3 +21,4 @@ identity:
 tools:
   - tools/slack_post_to_thread.yaml
   - tools/slack_post_to_channel.yaml
+  - tools/slack_add_reaction.yaml

--- a/tools/slack_add_reaction.py
+++ b/tools/slack_add_reaction.py
@@ -1,0 +1,70 @@
+from typing import Any, Generator
+import httpx
+from dify_plugin.entities.tool import ToolInvokeMessage
+from dify_plugin import Tool
+
+
+class SlackAddReactionTool(Tool):
+    def _invoke(
+        self, tool_parameters: dict[str, Any]
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        """Add a reaction to a Slack message.
+        API Document: https://api.slack.com/methods/reactions.add
+        """
+        bot_token = tool_parameters.get("bot_token", "").strip()
+        if not bot_token:
+            yield self.create_text_message("Invalid parameter: 'bot_token' is required.")
+            return
+
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {bot_token}",
+        }
+
+        channel_id = tool_parameters.get("channel_id", "")
+        if not channel_id:
+            yield self.create_text_message("Invalid parameter: 'channel_id' is required.")
+            return
+
+        icon_name = tool_parameters.get("icon_name", "")
+        if not icon_name:
+            yield self.create_text_message("Invalid parameter: 'icon_name' is required.")
+            return
+
+        timestamp = tool_parameters.get("timestamp", "")
+        if not timestamp:
+            yield self.create_text_message("Invalid parameter: 'timestamp' is required.")
+            return
+
+        payload = {
+            "channel": channel_id,
+            "name": icon_name,
+            "timestamp": timestamp,
+        }
+
+        try:
+            res = httpx.post(
+                "https://slack.com/api/reactions.add",
+                headers=headers,
+                json=payload,
+            )
+
+            if not res.is_success:
+                yield self.create_text_message(
+                    f"HTTP status code: {res.status_code}, response: {res.text}"
+                )
+                return
+
+            data = res.json()
+            if not data.get("ok", False):
+                yield self.create_text_message(
+                    f"Slack API error: {data.get('error', 'unknown_error')}"
+                )
+                return
+
+        except Exception as e:
+            yield self.create_text_message(f"Exception occurred: {str(e)}")
+            return
+
+        yield self.create_text_message("Reaction added successfully.")
+

--- a/tools/slack_add_reaction.yaml
+++ b/tools/slack_add_reaction.yaml
@@ -1,0 +1,97 @@
+description:
+  human:
+    en_US: Add a reaction to a Slack message
+    pt_BR: Adicionar uma reação a uma mensagem do Slack
+    zh_Hans: 给 Slack 消息添加表情反应
+    ja_JP: Slackメッセージにリアクションを追加
+  llm: A tool for adding reactions to Slack messages.
+
+extra:
+  python:
+    source: tools/slack_add_reaction.py
+
+identity:
+  author: solaoi
+  icon: icon.svg
+  label:
+    en_US: Slack Add Reaction
+    pt_BR: Slack Add Reaction
+    zh_Hans: Slack 添加表情
+    ja_JP: Slack リアクション追加
+  description:
+    en_US: Add a reaction emoji to a specified Slack message
+    pt_BR: Adiciona um emoji de reação a uma mensagem específica do Slack
+    zh_Hans: 为指定的 Slack 消息添加表情符号
+    ja_JP: 指定したSlackメッセージにリアクションを付与
+  name: slack_add_reaction
+
+parameters:
+  - name: channel_id
+    type: string
+    required: true
+    label:
+      en_US: channel_id
+      pt_BR: channel_id
+      zh_Hans: channel_id
+      ja_JP: channel_id
+    human_description:
+      en_US: Slack channel ID where the message exists
+      pt_BR: ID do canal Slack onde a mensagem está
+      zh_Hans: 消息所在的 Slack 频道ID
+      ja_JP: メッセージが存在するSlackチャンネルID
+    llm_description: The Slack channel ID containing the message you want to react to.
+    form: llm
+
+  - name: icon_name
+    type: string
+    required: true
+    label:
+      en_US: icon_name
+      pt_BR: icon_name
+      zh_Hans: icon_name
+      ja_JP: icon_name
+    human_description:
+      en_US: "Emoji name without surrounding colons (e.g., 'thumbsup' for :thumbsup:)"
+      pt_BR: "Nome do emoji sem os dois-pontos (ex.: 'thumbsup' para :thumbsup:)"
+      zh_Hans: "去掉两端冒号的表情名称（例如 :thumbsup: 写为 'thumbsup'）"
+      ja_JP: "Slack上では :thumbsup: と記載するため、コロン(:)で囲まない絵文字名（thumbsup など）を入力"
+    llm_description: "The emoji name to add as a reaction, without the surrounding ':' characters."
+    form: llm
+
+  - name: timestamp
+    type: string
+    required: true
+    label:
+      en_US: timestamp
+      pt_BR: timestamp
+      zh_Hans: timestamp
+      ja_JP: timestamp
+    human_description:
+      en_US: Timestamp of the Slack message
+      pt_BR: Timestamp da mensagem do Slack
+      zh_Hans: Slack 消息的时间戳
+      ja_JP: Slackメッセージのタイムスタンプ
+    llm_description: The timestamp of the message to which the reaction will be added.
+    form: llm
+
+  - name: bot_token
+    type: secret-input
+    required: true
+    label:
+      en_US: "Bot Token"
+      zh_Hans: "Bot Token"
+      pt_BR: "Token do Bot"
+      ja_JP: "Bot Token"
+    placeholder:
+      en_US: "Please enter the Bot Token"
+      zh_Hans: "请输入 Bot Token"
+      pt_BR: "Por favor, insira o Token do Bot"
+      ja_JP: "Bot Tokenを入力してください"
+    human_description:
+      en_US: "An optional Bot Token for this specific usage."
+      zh_Hans: "可选的 Bot Token、用于本次使用。"
+      pt_BR: "Um Token do Bot opcional para este uso específico."
+      ja_JP: "今回利用する個別のBot Token。"
+    llm_description: "If provided, this Bot Token will be used for the current action."
+    form: form
+

--- a/tools/slack_add_reaction.yaml
+++ b/tools/slack_add_reaction.yaml
@@ -1,0 +1,97 @@
+description:
+  human:
+    en_US: Add a reaction to a Slack message
+    pt_BR: Adicionar uma reação a uma mensagem do Slack
+    zh_Hans: 给 Slack 消息添加表情反应
+    ja_JP: Slackメッセージにリアクションを追加
+  llm: A tool for adding reactions to Slack messages.
+
+extra:
+  python:
+    source: tools/slack_add_reaction.py
+
+identity:
+  author: solaoi
+  icon: icon.svg
+  label:
+    en_US: Slack Add Reaction
+    pt_BR: Slack Add Reaction
+    zh_Hans: Slack 添加表情
+    ja_JP: Slack リアクション追加
+  description:
+    en_US: Add a reaction emoji to a specified Slack message
+    pt_BR: Adiciona um emoji de reação a uma mensagem específica do Slack
+    zh_Hans: 为指定的 Slack 消息添加表情符号
+    ja_JP: 指定したSlackメッセージにリアクションを付与
+  name: slack_add_reaction
+
+parameters:
+  - name: channel_id
+    type: string
+    required: true
+    label:
+      en_US: channel_id
+      pt_BR: channel_id
+      zh_Hans: channel_id
+      ja_JP: channel_id
+    human_description:
+      en_US: Slack channel ID where the message exists
+      pt_BR: ID do canal Slack onde a mensagem está
+      zh_Hans: 消息所在的 Slack 频道ID
+      ja_JP: メッセージが存在するSlackチャンネルID
+    llm_description: The Slack channel ID containing the message you want to react to.
+    form: llm
+
+  - name: icon_name
+    type: string
+    required: true
+    label:
+      en_US: icon_name
+      pt_BR: icon_name
+      zh_Hans: icon_name
+      ja_JP: icon_name
+    human_description:
+      en_US: Name of the emoji icon (e.g., thumbsup)
+      pt_BR: Nome do ícone emoji (ex: thumbsup)
+      zh_Hans: 表情符号名称（例如 thumbsup）
+      ja_JP: 絵文字の名前（例: thumbsup）
+    llm_description: The emoji name to add as a reaction.
+    form: llm
+
+  - name: timestamp
+    type: string
+    required: true
+    label:
+      en_US: timestamp
+      pt_BR: timestamp
+      zh_Hans: timestamp
+      ja_JP: timestamp
+    human_description:
+      en_US: Timestamp of the Slack message
+      pt_BR: Timestamp da mensagem do Slack
+      zh_Hans: Slack 消息的时间戳
+      ja_JP: Slackメッセージのタイムスタンプ
+    llm_description: The timestamp of the message to which the reaction will be added.
+    form: llm
+
+  - name: bot_token
+    type: secret-input
+    required: true
+    label:
+      en_US: "Bot Token"
+      zh_Hans: "Bot Token"
+      pt_BR: "Token do Bot"
+      ja_JP: "Bot Token"
+    placeholder:
+      en_US: "Please enter the Bot Token"
+      zh_Hans: "请输入 Bot Token"
+      pt_BR: "Por favor, insira o Token do Bot"
+      ja_JP: "Bot Tokenを入力してください"
+    human_description:
+      en_US: "An optional Bot Token for this specific usage."
+      zh_Hans: "可选的 Bot Token、用于本次使用。"
+      pt_BR: "Um Token do Bot opcional para este uso específico."
+      ja_JP: "今回利用する個別のBot Token。"
+    llm_description: "If provided, this Bot Token will be used for the current action."
+    form: form
+


### PR DESCRIPTION
## Summary
- add slack_add_reaction.py tool to add emoji reactions to messages
- add slack_add_reaction.yaml tool config
- register new tool in provider

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - Slackメッセージに絵文字リアクションを追加できるツールが利用可能になりました。指定したチャンネル、メッセージ、絵文字名を入力することで、簡単にリアクションを付与できます。
  - SlackのOAuthスコープに`reactions:write`が追加され、リアクション機能の利用が可能になりました。
  - ドキュメントが更新され、リアクション追加機能の使い方や必要な入力変数が各言語で詳述されています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->