### PR TITLE
Add Slack reaction tool

### DIFF
--- a/provider/slack_post.yaml
+++ b/provider/slack_post.yaml
@@ -21,3 +21,4 @@ identity:
 tools:
   - tools/slack_post_to_thread.yaml
   - tools/slack_post_to_channel.yaml
+  - tools/slack_add_reaction.yaml

--- a/tools/slack_add_reaction.py
+++ b/tools/slack_add_reaction.py
@@ -1,0 +1,70 @@
+from typing import Any, Generator
+import httpx
+from dify_plugin.entities.tool import ToolInvokeMessage
+from dify_plugin import Tool
+
+
+class SlackAddReactionTool(Tool):
+    def _invoke(
+        self, tool_parameters: dict[str, Any]
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        """Add a reaction to a Slack message.
+        API Document: https://api.slack.com/methods/reactions.add
+        """
+        bot_token = tool_parameters.get("bot_token", "").strip()
+        if not bot_token:
+            yield self.create_text_message("Invalid parameter: 'bot_token' is required.")
+            return
+
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {bot_token}",
+        }
+
+        channel_id = tool_parameters.get("channel_id", "")
+        if not channel_id:
+            yield self.create_text_message("Invalid parameter: 'channel_id' is required.")
+            return
+
+        icon_name = tool_parameters.get("icon_name", "")
+        if not icon_name:
+            yield self.create_text_message("Invalid parameter: 'icon_name' is required.")
+            return
+
+        timestamp = tool_parameters.get("timestamp", "")
+        if not timestamp:
+            yield self.create_text_message("Invalid parameter: 'timestamp' is required.")
+            return
+
+        payload = {
+            "channel": channel_id,
+            "name": icon_name,
+            "timestamp": timestamp,
+        }
+
+        try:
+            res = httpx.post(
+                "https://slack.com/api/reactions.add",
+                headers=headers,
+                json=payload,
+            )
+
+            if not res.is_success:
+                yield self.create_text_message(
+                    f"HTTP status code: {res.status_code}, response: {res.text}"
+                )
+                return
+
+            data = res.json()
+            if not data.get("ok", False):
+                yield self.create_text_message(
+                    f"Slack API error: {data.get('error', 'unknown_error')}"
+                )
+                return
+
+        except Exception as e:
+            yield self.create_text_message(f"Exception occurred: {str(e)}")
+            return
+
+        yield self.create_text_message("Reaction added successfully.")
+

--- a/tools/slack_add_reaction.yaml
+++ b/tools/slack_add_reaction.yaml
@@ -1,0 +1,97 @@
+description:
+  human:
+    en_US: Add a reaction to a Slack message
+    pt_BR: Adicionar uma reação a uma mensagem do Slack
+    zh_Hans: 给 Slack 消息添加表情反应
+    ja_JP: Slackメッセージにリアクションを追加
+  llm: A tool for adding reactions to Slack messages.
+
+extra:
+  python:
+    source: tools/slack_add_reaction.py
+
+identity:
+  author: solaoi
+  icon: icon.svg
+  label:
+    en_US: Slack Add Reaction
+    pt_BR: Slack Add Reaction
+    zh_Hans: Slack 添加表情
+    ja_JP: Slack リアクション追加
+  description:
+    en_US: Add a reaction emoji to a specified Slack message
+    pt_BR: Adiciona um emoji de reação a uma mensagem específica do Slack
+    zh_Hans: 为指定的 Slack 消息添加表情符号
+    ja_JP: 指定したSlackメッセージにリアクションを付与
+  name: slack_add_reaction
+
+parameters:
+  - name: channel_id
+    type: string
+    required: true
+    label:
+      en_US: channel_id
+      pt_BR: channel_id
+      zh_Hans: channel_id
+      ja_JP: channel_id
+    human_description:
+      en_US: Slack channel ID where the message exists
+      pt_BR: ID do canal Slack onde a mensagem está
+      zh_Hans: 消息所在的 Slack 频道ID
+      ja_JP: メッセージが存在するSlackチャンネルID
+    llm_description: The Slack channel ID containing the message you want to react to.
+    form: llm
+
+  - name: icon_name
+    type: string
+    required: true
+    label:
+      en_US: icon_name
+      pt_BR: icon_name
+      zh_Hans: icon_name
+      ja_JP: icon_name
+    human_description:
+      en_US: Name of the emoji icon (e.g., thumbsup)
+      pt_BR: Nome do ícone emoji (ex: thumbsup)
+      zh_Hans: 表情符号名称（例如 thumbsup）
+      ja_JP: 絵文字の名前（例: thumbsup）
+    llm_description: The emoji name to add as a reaction.
+    form: llm
+
+  - name: timestamp
+    type: string
+    required: true
+    label:
+      en_US: timestamp
+      pt_BR: timestamp
+      zh_Hans: timestamp
+      ja_JP: timestamp
+    human_description:
+      en_US: Timestamp of the Slack message
+      pt_BR: Timestamp da mensagem do Slack
+      zh_Hans: Slack 消息的时间戳
+      ja_JP: Slackメッセージのタイムスタンプ
+    llm_description: The timestamp of the message to which the reaction will be added.
+    form: llm
+
+  - name: bot_token
+    type: secret-input
+    required: true
+    label:
+      en_US: "Bot Token"
+      zh_Hans: "Bot Token"
+      pt_BR: "Token do Bot"
+      ja_JP: "Bot Token"
+    placeholder:
+      en_US: "Please enter the Bot Token"
+      zh_Hans: "请输入 Bot Token"
+      pt_BR: "Por favor, insira o Token do Bot"
+      ja_JP: "Bot Tokenを入力してください"
+    human_description:
+      en_US: "An optional Bot Token for this specific usage."
+      zh_Hans: "可选的 Bot Token、用于本次使用。"
+      pt_BR: "Um Token do Bot opcional para este uso específico."
+      ja_JP: "今回利用する個別のBot Token。"
+    llm_description: "If provided, this Bot Token will be used for the current action."
+    form: form
+


### PR DESCRIPTION
## Summary
- add slack_add_reaction.py tool to add emoji reactions to messages
- add slack_add_reaction.yaml tool config
- register new tool in provider

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6837181dc98883279f6918de8e8ee9d1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 指定したSlackメッセージに絵文字リアクションを追加できるツールを新たに導入しました。ユーザーはチャンネルID、絵文字名、メッセージのタイムスタンプ、ボットトークンを入力して、Slackメッセージへリアクションを付与できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->